### PR TITLE
feat: redirect screen recordings to Downloads\ScreenRecordings

### DIFF
--- a/Environment/ENVIRONMENT-MONEY-INSTALL/02.Setup01.ps1
+++ b/Environment/ENVIRONMENT-MONEY-INSTALL/02.Setup01.ps1
@@ -129,6 +129,10 @@ Set-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\
 ## Reference: https://superuser.com/a/1829862/1720344
 [microsoft.win32.registry]::SetValue("HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders", "{B7BEDE81-DF94-4682-A7D8-57A52620B86F}", "%UserProfile%\Downloads\ScreenShots")
 
+# Set screen recording save location (used by Snipping Tool video & Xbox Game Bar)
+## Known folder: Captures (FOLDERID_Captures), default path %USERPROFILE%\Videos\Captures
+[microsoft.win32.registry]::SetValue("HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders", "{EDC0FE71-98D8-4F4A-B920-C8DC133CB165}", "%UserProfile%\Downloads\ScreenRecordings")
+
 # Set receive update for other Microsoft product
 $ServiceManager = New-Object -ComObject "Microsoft.Update.ServiceManager"
 $ServiceManager.ClientApplicationID = "My App"


### PR DESCRIPTION
## 摘要

在 `Environment\ENVIRONMENT-MONEY-INSTALL\02.Setup01.ps1` 既有「Screenshots → `%UserProfile%\Downloads\ScreenShots`」設定之後，新增一段同樣寫法的設定，把 Windows 的螢幕錄影 Known Folder 重新導向至 `%UserProfile%\Downloads\ScreenRecordings`。

之後 Snipping Tool 的螢幕錄影 (Win+Shift+R)、Xbox Game Bar 等寫入 `Captures` Known Folder 的工具都會集中存放在 `Downloads\ScreenRecordings`，與 Screenshots 並列。

## 變更內容

- File: `Environment\ENVIRONMENT-MONEY-INSTALL\02.Setup01.ps1` (+4)
- Known Folder GUID: `{EDC0FE71-98D8-4F4A-B920-C8DC133CB165}` (FOLDERID_Captures，預設 `%USERPROFILE%\Videos\Captures`)
- Registry path: `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders`（與既有 Screenshots 相同）

```diff
@@ -129,6 +129,10 @@ Set-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\
 ## Reference: https://superuser.com/a/1829862/1720344
 [microsoft.win32.registry]::SetValue(...""{B7BEDE81-DF94-4682-A7D8-57A52620B86F}"", ""%UserProfile%\Downloads\ScreenShots"")

+# Set screen recording save location (used by Snipping Tool video & Xbox Game Bar)
+## Known folder: Captures (FOLDERID_Captures), default path %USERPROFILE%\Videos\Captures
+[microsoft.win32.registry]::SetValue(...""{EDC0FE71-98D8-4F4A-B920-C8DC133CB165}"", ""%UserProfile%\Downloads\ScreenRecordings"")
+
```

## 驗證

- GUID 透過本機 `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions\{EDC0FE71-98D8-4F4A-B920-C8DC133CB165}` 確認為 `Name=Captures`、`ParentFolder={18989B1D-99B5-455B-841C-AB7C74E4DDFC}` (My Video)、`RelativePath=Captures`
- PowerShell parser (`[System.Management.Automation.Language.Parser]::ParseFile`) 對修改後的腳本回報 0 errors / 4029 tokens
- `REG_SZ` vs `REG_EXPAND_SZ`：`User Shell Folders` 鍵值由 Shell API 處理，兩種型別都會展開 `%UserProfile%`；既有 Screenshots 設定也使用 `[microsoft.win32.registry]::SetValue` (即 REG_SZ)，已實際運作驗證

## 設計決策

- 不顯式建立資料夾：與既有 Screenshots 行為一致，Windows 在首次寫入時會自動建立
- 不額外加 `Show-Section` / `Show-Success`：與該段所有 Registry 寫入的風格一致
- 未變更 README：既有 Screenshots 設定本來就未在 README 中文件化

## 影響範圍

- 新使用者執行 setup 後，螢幕錄影會直接存到 `Downloads\ScreenRecordings`
- 已存在 `Videos\Captures` 內的舊檔案不會被搬動，亦不會被刪除
