### PR TITLE
docs: update CHANGELOG for release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-13
+
 ### Added
-- 05.Driver.ps1 — auto-detect NVIDIA GPU and install the latest Game Ready Driver (GRD, DCH) via NVIDIA's lookup API; no automatic reboot
-- 05.Driver.ps1 — ensure Chocolatey is installed (self-bootstrap when missing) and install NZXT CAM via Chocolatey on `MONEY-PC`
-- 05.Driver.ps1 — install Wacom Tablet driver via Chocolatey on every host
-- 05.Driver.ps1 — drive Logi Options+ silent install via the upstream [`Qetesh/logi-options-plus-mini`](https://github.com/Qetesh/logi-options-plus-mini) PowerShell wrapper (Quiet/SSO/Update/DFU/Backlight enabled; telemetry & AI features off; forced English / international URL); credit Qetesh
-- 02.Setup01.ps1 — install GitHub CLI (`gh`) via Chocolatey and add the `gh-copilot` extension (matches the macOS install script)
-- 02.Setup01.ps1 — install Typeless (AI voice dictation) via winget (`SimplyCA.Typeless`)
+- 05.Driver.ps1 — auto-detect NVIDIA GPU and install the latest Game Ready Driver (GRD, DCH) via NVIDIA's lookup API; no automatic reboot (#46)
+- 05.Driver.ps1 — ensure Chocolatey is installed (self-bootstrap when missing) and install NZXT CAM via Chocolatey on `MONEY-PC` (#46)
+- 05.Driver.ps1 — install Wacom Tablet driver via Chocolatey on every host (#46)
+- 05.Driver.ps1 — drive Logi Options+ silent install via the upstream [`Qetesh/logi-options-plus-mini`](https://github.com/Qetesh/logi-options-plus-mini) PowerShell wrapper (Quiet/SSO/Update/DFU/Backlight enabled; telemetry & AI features off; forced English / international URL); credit Qetesh (#46)
+- 02.Setup01.ps1 — install GitHub CLI (`gh`) via Chocolatey and add the `gh-copilot` extension (matches the macOS install script) (#46)
+- 02.Setup01.ps1 — install Typeless (AI voice dictation) via winget (`SimplyCA.Typeless`) (#46)
+- 02.Setup01.ps1 — redirect screen recording save location (`FOLDERID_Captures`, used by Snipping Tool video & Xbox Game Bar) to `%UserProfile%\Downloads\ScreenRecordings`, mirroring the existing Screenshots redirect (#47)
+- 00.PreConfig.ps1 — automated language pack installation with configurable input methods (#44)
 - Step 5 (NVIDIA Driver) sections in README.md and README.zh-TW.md
+
+### Fixed
+- UTF-8 encoding issues in remote PowerShell command execution by replacing `WebClient` with `Invoke-RestMethod` (#45)
 
 ## [1.1.1] - 2025-12-17
 
@@ -127,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PowerShell with Administrator privileges
 - Internet connection
 
-[Unreleased]: https://github.com/lettucebo/Ci.Environment/compare/v1.1.1...HEAD
-[1.1.1]: https://github.com/lettucebo/Ci.Environment/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/lettucebo/Ci.Environment/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/lettucebo/Ci.Environment/releases/tag/v1.0.0
+[Unreleased]: https://github.com/lettucebo/Ci.Environment/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/lettucebo/Ci.Environment/compare/1.1.1...1.2.0
+[1.1.1]: https://github.com/lettucebo/Ci.Environment/compare/1.1.0...1.1.1
+[1.1.0]: https://github.com/lettucebo/Ci.Environment/compare/1.0.0...1.1.0
+[1.0.0]: https://github.com/lettucebo/Ci.Environment/releases/tag/1.0.0


### PR DESCRIPTION
## 摘要

為即將發佈的 `1.2.0` 版本更新 `CHANGELOG.md`。

- 將既有 `[Unreleased]` 區段（PR #46 的 NVIDIA Driver / NZXT CAM / Wacom / Logi Options+ / gh CLI / Typeless）正式歸入 `[1.2.0] - 2026-05-13`
- 新增條目：
  - `02.Setup01.ps1` — 螢幕錄影 Known Folder 重新導向至 `Downloads\ScreenRecordings` (#47)
  - `00.PreConfig.ps1` — 自動安裝語言包 + 可設定的輸入法 (#44)
  - **Fixed** — UTF-8 encoding by `Invoke-RestMethod` (#45)
- 修正既有 compare 連結：原本使用 `v1.x.y` 但實際 tag 並無 `v` 前綴（1.0.0 / 1.1.0 / 1.1.1），調整為與 tag 一致

## 合併後
- 在合併後的 master 上建立 tag `1.2.0` 與 GitHub Release `1.2.0`

無程式碼變更，純文件更新。
