### PR TITLE
chore: ignore .github/skills (Copilot CLI runtime artifacts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ $RECYCLE.BIN/
 
 # PowerShell
 *.pssc
+
+# Copilot CLI / agent runtime artifacts (auto-generated skill packs, not part of the repo)
+.github/skills/


### PR DESCRIPTION
## 摘要

將 `.github/skills/` 加入 `.gitignore`。

該目錄是 Copilot CLI 在執行時自動寫入的通用技能包（`chrome-devtools`、`gh-cli`、`git-commit`、`github-issues`、`microsoft-docs`、`code-review`、`create-readme`），約 300 KB，與本倉庫（Windows 安裝腳本）無關，不應被誤 commit。

加入忽略後仍可在本機保留這些檔案，後續任何 `git status` 都不會再列出它們。

## 驗證

```
\$ git check-ignore -v .github/skills/code-review/SKILL.md
.gitignore:25:.github/skills/   .github/skills/code-review/SKILL.md
```

僅 `.gitignore` 一行新增 + 一行 comment。
