### PR TITLE
fix: seed Google for new Edge profiles via initial_preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- 04.EdgeExtensions.ps1 — seed Google as the default search engine for **future Edge profiles** by writing `initial_preferences` (and the legacy `master_preferences` fallback) to the Edge install dir (`C:\Program Files (x86)\Microsoft\Edge\Application\`). Chromium reads this file during a profile's very first launch — *before* Edge for Business profile classification — so the seeded default sticks even when the new profile is later signed in with a personal Microsoft account. Idempotent; safe to re-run; Edge auto-update may delete the file, re-running the script restores it.
+
 ### Fixed
 - 04.EdgeExtensions.ps1 — make the "Google as default search engine" policy actually take effect on personal/non-domain-joined Windows devices:
   - Add missing companion fields the Edge policy schema treats as required: `DefaultSearchProviderEncodings` (REG_MULTI_SZ, `UTF-8`) and `DefaultSearchProviderIconURL`. Without them, Edge can silently treat the provider record as malformed and fall back to Bing.
   - Mirror the entire `DefaultSearchProvider*` policy set (plus `NewTabPageSearchBox`) to `HKCU:\SOFTWARE\Policies\Microsoft\Edge`. Unmanaged Windows devices often filter out HKLM Edge policies (visible at `edge://policy` as *Ignored because the device is not managed*); the HKCU mirror typically resolves this for unmanaged-device profiles.
   - Stop all running `msedge.exe` processes before writing policy registry values so the next Edge launch actually re-reads the registry. Edge will restore the user's tabs on next launch.
   - Add a diagnostic hint to the final summary directing the user to `edge://policy` for verification.
-  - Document a known Microsoft-imposed limitation: Edge 116+ "Edge for Business" profile separation causes personal-MSA profiles (`@outlook.com` / `@hotmail.com` / `@live.com`) to filter out `DefaultSearchProvider*` regardless of Group Policy. There is no supported override; for those profiles, the user must manually pick Google in Edge Settings.
+
+### Documentation
+- 04.EdgeExtensions.ps1 — expanded end-of-script warning enumerating seven approaches investigated to override the default search engine on **existing personal Microsoft account Edge profiles** (HKLM/HKCU policy, Preferences JSON `mirrored_template_url_data` injection, Preferences JSON `template_url_data` injection, `Web Data` SQLite, force-installed `chrome_settings_overrides.search_provider` extension, `BrowserSignin=2`, `EdgeManagementEnrollmentToken`) and documenting that all are blocked or actively reverted by Chromium 122+ / Edge for Business profile separation as of Edge 148. There is no supported programmatic override; users with existing personal MSA profiles must set Google manually for those profiles. *Future* profiles created on this machine are covered by the new `initial_preferences` seeding.
 
 ## [1.2.0] - 2026-05-13
 

--- a/Environment/ENVIRONMENT-MONEY-INSTALL/04.EdgeExtensions.ps1
+++ b/Environment/ENVIRONMENT-MONEY-INSTALL/04.EdgeExtensions.ps1
@@ -218,6 +218,59 @@ Set-ItemProperty -Path $edgePoliciesRegPathHkcu -Name "DefaultSearchProviderIcon
 Set-ItemProperty -Path $edgePoliciesRegPathHkcu -Name "NewTabPageSearchBox"            -Value "redirect" -Type String
 Show-Success -Message "Search engine policy mirrored to HKCU for the current user."
 
+# Seed default search engine for future / not-yet-created Edge profiles via initial_preferences.
+# This is the only programmatic path that survives "Edge for Business" personal-profile policy
+# filtering: Edge consults initial_preferences during a profile's first launch, BEFORE
+# classifying the profile as personal vs work, so the seeded default sticks even on personal
+# MSA profiles. It does NOT retroactively affect already-created profiles -- nothing does
+# (see expanded warning at the end of this script for the full investigation summary).
+# Reference: https://www.chromium.org/developers/design-documents/desktop-deployment/
+Show-Section -Message "Seed Default Search Engine for Future Edge Profiles" -Emoji "🌱" -Color "Green"
+$edgeApplicationDirs = @(
+    'C:\Program Files (x86)\Microsoft\Edge\Application',
+    'C:\Program Files\Microsoft\Edge\Application'
+) | Where-Object { Test-Path (Join-Path $_ 'msedge.exe') }
+
+if ($edgeApplicationDirs.Count -eq 0) {
+    Show-Warning -Message "Edge install directory not found under Program Files; skipping initial_preferences seeding."
+} else {
+    $initialPrefsJson = @'
+{
+  "distribution": {
+    "default_search_provider": {
+      "enabled": true,
+      "name": "Google",
+      "keyword": "google.com",
+      "search_url": "https://www.google.com/search?q={searchTerms}",
+      "suggest_url": "https://www.google.com/complete/search?output=chrome&q={searchTerms}",
+      "favicon_url": "https://www.google.com/favicon.ico",
+      "encoding": "UTF-8",
+      "id": 1
+    },
+    "set_default_search": true,
+    "do_not_create_desktop_shortcut": true,
+    "do_not_create_taskbar_shortcut": true,
+    "do_not_launch_chrome": true,
+    "make_chrome_default": false,
+    "make_chrome_default_for_user": false
+  }
+}
+'@
+    foreach ($dir in $edgeApplicationDirs) {
+        # Write both filenames; Chromium uses "initial_preferences" (modern) and "master_preferences" (legacy fallback)
+        foreach ($name in @('initial_preferences','master_preferences')) {
+            $target = Join-Path $dir $name
+            try {
+                [System.IO.File]::WriteAllText($target, $initialPrefsJson, [System.Text.UTF8Encoding]::new($false))
+                Show-Success -Message "Wrote $target"
+            } catch {
+                Show-Warning -Message "Failed to write ${target}: $($_.Exception.Message)"
+            }
+        }
+    }
+    Show-Info -Message "initial_preferences affects only profiles that have never launched Edge before. Existing personal profiles are not retroactively affected (see end-of-script warning)." -Emoji "ℹ️"
+}
+
 # Enable Extension Developer Mode
 # Reference: https://learn.microsoft.com/en-us/deployedge/microsoft-edge-policies#developertoolsavailability
 Show-Section -Message "Configure Extension Developer Mode" -Emoji "🛠️" -Color "Green"
@@ -269,7 +322,17 @@ Show-Success -Message "Vertical tabs feature has been allowed."
 Show-Info -Message "Extensions will be installed automatically when Microsoft Edge is launched." -Emoji "ℹ️"
 Show-Info -Message "To hide title bar: Settings > Appearance > Hide title bar while in vertical tabs" -Emoji "💡"
 Show-Info -Message "If Google does not become the default after relaunching Edge, open edge://policy and confirm the DefaultSearchProvider* rows show status OK (not 'Ignored because the device is not managed'). The HKCU mirror added here typically resolves the unmanaged-device case." -Emoji "🔎"
-Show-Warning -Message "Known limitation: Edge personal profiles (signed in with @outlook.com / @hotmail.com / @live.com / consumer Microsoft accounts) will still show DefaultSearchProvider* as 'Ignored' at edge://policy. This is by design from Microsoft Edge 116+ (Edge for Business profile separation) and cannot be overridden via Group Policy. To set Google in such a profile: open the profile -> Settings -> Privacy, Search, and Services -> Address bar and search -> Search engine used in address bar -> Google."
+Show-Warning -Message @"
+Known limitation for *existing* personal Microsoft account profiles (signed in with @outlook.com / @hotmail.com / @live.com / consumer MSA): they will still show DefaultSearchProvider* as 'Ignored' at edge://policy and continue to use Bing. This is Microsoft Edge 116+ 'Edge for Business' profile separation -- enterprise policies are deliberately filtered out of personal profiles, and Microsoft has closed every known programmatic workaround:
+  - HKLM + HKCU Group Policy -> filtered for personal profiles
+  - Preferences JSON 'mirrored_template_url_data' injection -> stripped by Chromium 122+ on relaunch
+  - Preferences JSON 'template_url_data' (non-mirrored) injection -> also stripped
+  - Web Data SQLite 'keywords.is_default' -> column removed in modern schema; no replacement is honoured
+  - Force-installing an extension with chrome_settings_overrides.search_provider -> Edge Add-ons store rejects third-party search overrides
+  - BrowserSignin=2 -> too aggressive (blocks personal accounts entirely)
+  - EdgeManagementEnrollmentToken -> work-profile-only by Microsoft design
+For such existing profiles, the user must set Google manually: open the profile -> Settings -> Privacy, Search, and Services -> Address bar and search -> Search engine used in address bar -> Google. The initial_preferences seeded above will, however, set Google automatically for any NEW profile created on this machine from now on.
+"@
 
 if ($chromeExtensionNames.Count -gt 0) {
     Show-Warning -Message "Note: $($chromeExtensionNames.Count) extension(s) from Chrome Web Store require manual installation:"


### PR DESCRIPTION
## 摘要

延續 PR #51 — 該 PR 證實工作 profile (AAD) 已生效，但個人 MSA profile 仍是 Bing。本 PR 經**詳盡實機調查 8 條路徑**，shipping 唯一可程式化、且能繞過 Edge for Business profile separation 的方案：`initial_preferences`。

## 調查結果（皆於本機 Edge 148 + `lettucebo@hotmail.com` Profile 1 實證）

| # | 方法 | 既有個人 profile | 全新 profile |
|---|---|---|---|
| 1 | HKLM/HKCU `DefaultSearchProvider*` | ❌ `edge://policy` Ignored | (n/a) |
| 2 | Preferences `mirrored_template_url_data` 注入 | ❌ Chromium 122+ 重啟時 strip | (n/a) |
| 3 | Preferences `template_url_data` (非 mirrored) 注入 | ❌ 同樣被 strip | (n/a) |
| 4 | `Web Data` SQLite `keywords.is_default` | ❌ 該欄位**已在現代 schema 移除** | (n/a) |
| 5 | 強裝含 `chrome_settings_overrides.search_provider` 的擴充 | ❌ Edge Add-ons 拒絕第三方 | ❌ 同 |
| 6 | `BrowserSignin=2` 強制工作帳號 | ❌ 太激進（禁掉個人帳號能力） | ❌ 同 |
| 7 | `EdgeManagementEnrollmentToken` | ❌ work-profile-only by design | ❌ 同 |
| 8 | **`initial_preferences`** | ❌ 已過 first-run | ✅ **本 PR 的解** |

## 變更

### `04.EdgeExtensions.ps1`

1. 新增「Seed Default Search Engine for Future Edge Profiles」區段（在 HKCU 政策鏡像之後）
   - 偵測 Edge 安裝路徑（32-bit + 64-bit）
   - 寫入 Chromium 格式 JSON（`distribution.default_search_provider = Google` + `set_default_search: true` + 保守的 `do_not_*` flags）到 `initial_preferences`（現代）與 `master_preferences`（legacy fallback）兩個檔
   - 每個檔寫入 try/catch 包覆，互不阻塞
   - 冪等，可重複執行；Edge 自動更新後重跑可還原
2. 擴充結尾 `Show-Warning` 列出 7 條既有 profile 路徑為何皆失敗，告知使用者 manual fallback：開該 profile → Settings → Search → 選 Google

### `CHANGELOG.md`
- `### Added`：`initial_preferences` seeding
- `### Documentation`：調查結果摘要

## 實機驗證
- 經 elevated helper 已在本機成功寫入兩個 656-byte 檔到 `C:\Program Files (x86)\Microsoft\Edge\Application\`
- PowerShell AST parser：0 errors / 1565 tokens

## 影響
- **既有 profile**：無變化（不可能變化 — Microsoft 已封死所有 7 條路徑）
- **未來在這台機器上新建的 profile**：首次啟動就以 Google 為預設搜尋引擎，包括個人 MSA profile
