### PR TITLE
docs: split Copilot instructions into path-scoped files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,79 +1,76 @@
-# Ci.Environment — Copilot Instructions
+# Ci.Environment — Copilot instructions
 
-This repo is **not application code**. It is a collection of PowerShell deployment scripts that bootstrap a Windows developer / server machine end-to-end (Windows configuration, Chocolatey/winget installs, registry tweaks, Edge policies, NVIDIA driver, Docker containers, etc.). There are no builds, no unit tests, and no CI — most changes are validated by syntax-parsing the script and reasoning about behavior, because actually running them requires an Administrator session on a real Windows host.
+This repo is **not application code**. It is a collection of standalone PowerShell (plus a few Bash) scripts that bootstrap a Windows developer / server machine end-to-end: Windows configuration, Chocolatey/winget/Marketplace installs, registry tweaks, Edge policies, NVIDIA driver, per-server-role setup, etc. There is **no build, no test runner, and no CI**. The only validation is parse-checking a script (see "Validating changes") and reasoning about behavior — actually running a script needs an elevated session on a real Windows host and makes persistent, system-wide changes, so **never execute these scripts to "test" them.**
 
-## Repository shape
+## Path-specific instructions
 
-- `Environment\ENVIRONMENT-MONEY-INSTALL\` — the canonical, ordered user-workstation setup. Filenames are **numbered prefixes that imply execution order**:
-  - `00.PreConfig.ps1` — bootstraps PowerShell 7 itself (the only script intended to run under Windows PowerShell 5.1)
+Deep, file-type-specific conventions live in `.github/instructions/` and are auto-applied by path. Read the matching file before editing:
+
+| When you edit… | Read |
+| --- | --- |
+| any `*.ps1` | `.github/instructions/powershell-scripts.instructions.md` |
+| `README*.md`, `ENVIRONMENT-MONEY.md` | `.github/instructions/readme-and-docs.instructions.md` |
+| `CHANGELOG.md` | `.github/instructions/changelog-and-releases.instructions.md` |
+
+(GitHub Copilot in VS Code and the coding agent load these automatically via their `applyTo` frontmatter; if your tool doesn't, open them manually.)
+
+## Repository map
+
+- `Environment\ENVIRONMENT-MONEY-INSTALL\` — the canonical, ordered user-workstation setup. Numbered filename prefixes imply run order:
+  - `00.PreConfig.ps1` — bootstraps PowerShell 7 (the only script meant to run under Windows PowerShell 5.1)
   - `01.WinUpdate.ps1`, `02.Setup01.ps1`, `03.Setup02.ps1`, `04.EdgeExtensions.ps1`, `05.Driver.ps1`
-  - `install-vsix.ps1` — helper invoked by `02.Setup01.ps1` to install VS Marketplace extensions
-  - `EdgeExtensions.md` — a list of Edge addon URLs parsed at runtime by `04.EdgeExtensions.ps1`
-- `Environment\ENVIRONMENT-MONEY-SANDBOX.ps1` — Windows Sandbox variant (legacy style, pre-Show-* helper era)
-- `Environment\ENVIRONMENT-MONEY-INSTALL-MAC.sh` — macOS counterpart (Homebrew / mas), kept loosely in sync with `02.Setup01.ps1` for tools like `gh` + `gh-copilot`
-- `Work\` — per-server-role bootstrap (`ENVIRONMENT-WIN-SERVER-{API,DB,WEB,SCHEDULE}-INSTALL.ps1`, `ENVIRONMENT-GATEWAY-INSTALL.ps1`, `ENVIRONMENT-MONEY-MS-INSTALL.ps1`)
+  - `install-vsix.ps1` — helper invoked by **`03.Setup02.ps1`** to install VS Marketplace extensions
+  - `EdgeExtensions.md` — Edge addon URLs parsed at runtime by `04.EdgeExtensions.ps1`
+- `Environment\ENVIRONMENT-MONEY-SANDBOX.ps1` — Windows Sandbox variant (legacy, pre-`Show-*` style)
+- `Environment\ENVIRONMENT-MONEY-INSTALL-MAC.sh` — macOS counterpart (Homebrew / mas), kept loosely in sync with `02.Setup01.ps1`
+- `Work\` — per-server-role bootstrap (`ENVIRONMENT-WIN-SERVER-{API,DB,WEB,SCHEDULE}-INSTALL.ps1`, `ENVIRONMENT-GATEWAY-INSTALL.ps1`, `ENVIRONMENT-MONEY-MS-INSTALL.ps1`) — legacy style
 - `Scripts\` — standalone utilities (`Cleanup.ps1`, `Optimize-WindowsServices.ps1`)
-- `Shells\` — misc one-off helpers (`AutoBingTeamsBg.ps1`, `UbuntuADOAgentInstall.sh`)
+- `Shells\` — one-off helpers (`AutoBingTeamsBg.ps1`, `UbuntuADOAgentInstall.sh`)
 - `Fonts\`, `Installer\` — binary assets shipped with the repo
-- `README.md` + `README.zh-TW.md` — **both must be updated together** for any user-visible change (a "Step N" section, tool added/removed, etc.)
+- `README.md` + `README.zh-TW.md` — English / Traditional-Chinese, structurally parallel; `ENVIRONMENT-MONEY.md` — long-form manual-install software list (zh-TW)
 
-## How users actually run these scripts
+## How these scripts run — and the two rules it forces
 
-The READMEs document the only supported invocation pattern: an elevated PowerShell session that pipes the raw GitHub URL through `iex (Invoke-RestMethod ...)`:
+The only supported invocation (documented in the READMEs) is an elevated PowerShell session piping the raw GitHub URL through `iex`:
 
 ```powershell
 iex (Invoke-RestMethod 'https://raw.githubusercontent.com/lettucebo/Ci.Environment/master/Environment/ENVIRONMENT-MONEY-INSTALL/02.Setup01.ps1')
 ```
 
-Because of this, **every script must work as a single self-contained file**. Two consequences fall out of this and you must respect them:
+So **every script must work as a single self-contained file**, which forces two non-negotiable rules:
 
-1. **`$PSScriptRoot` is empty under `iex`.** Whenever a script needs a sibling file (e.g. `02.Setup01.ps1` calls `install-vsix.ps1`; `04.EdgeExtensions.ps1` reads `EdgeExtensions.md`), it must fall back to downloading the file from `https://raw.githubusercontent.com/lettucebo/Ci.Environment/master/...`. See the existing `if ([string]::IsNullOrEmpty($PSScriptRoot)) { ... }` pattern at the top of `04.EdgeExtensions.ps1` and inside `02.Setup01.ps1`'s install-vsix block. New helper-file dependencies must follow the same fallback.
-2. **The `master` branch is the production target** — there is no `main`, no release branch. All raw URLs are hardcoded to `master/...`. If you rename / move a file under `Environment\ENVIRONMENT-MONEY-INSTALL\`, you must also grep for and update its `raw.githubusercontent.com/lettucebo/Ci.Environment/master/...` references.
+1. **`master` is the production branch** — there is no `main` and no long-lived release branch; `master` is the target every raw URL points at (ephemeral `release/<x.y.z>` branches are still used briefly during release prep — see the CHANGELOG instructions). Every `raw.githubusercontent.com/lettucebo/Ci.Environment/master/...` URL is hardcoded to `master/`. If you move or rename a file under `Environment\ENVIRONMENT-MONEY-INSTALL\`, grep for and update its raw URLs.
+2. **Under `iex`, `$PSScriptRoot` is empty**, so a script cannot assume sibling files are on disk. Sibling *script/text* dependencies must fall back to downloading from the `master` raw URL (e.g. `04.EdgeExtensions.ps1` → `EdgeExtensions.md`; `03.Setup02.ps1` → `install-vsix.ps1`). The exact pattern is in the PowerShell instructions.
 
-Use `Invoke-RestMethod` / `Invoke-WebRequest`, **not** `New-Object System.Net.WebClient` — the latter caused a UTF-8 corruption bug fixed in PR #45 and should not be reintroduced.
+Fetch **this repo's own** scripts/text with `Invoke-RestMethod` / `Invoke-WebRequest`, not `WebClient.DownloadString` — `WebClient` corrupts their UTF-8 (emoji + Traditional Chinese); that was the #45 bug (which rewrote the READMEs' `iex` one-liners). The plain-ASCII Chocolatey bootstrap one-liner that uses `WebClient` is the deliberate exception and is still present in `02`, `05`, and the `Work\` scripts — don't "fix" it.
 
-## Conventions every script follows
+## Validating changes (the closest thing to tests)
 
-Each numbered script (`00`–`05`, `01.WinUpdate`, etc.) opens with the same boilerplate; new scripts in this family must too:
+Parse-check any modified PowerShell file; do **not** run it:
 
-1. **Re-declare the `Show-*` helper functions** (`Show-Section`, `Show-Info`, `Show-Warning`, `Show-Error`, `Show-Success`) verbatim at the top. They are deliberately duplicated per file because each script is delivered standalone via `iex`. Do not refactor them into a shared module.
-2. **Admin + version gates, in this order:**
-   ```powershell
-   Set-ExecutionPolicy RemoteSigned -Force
-   # WindowsPrincipal IsInRole "Administrator"  -> exit if false
-   if ($PSversionTable.PsVersion.Major -lt 7) { exit }   # except 00.PreConfig
-   ```
-3. **Visual structure with emoji.** Each logical phase is announced via `Show-Section -Message "..." -Emoji "..." -Color "..."`, with `Show-Success` / `Show-Error` after the action. Multi-step setup phases are numbered inline (e.g. `[1/8] Install Node.js using nvm`). Stay in this style for new sections.
-4. **Registry writes** use either `[microsoft.win32.registry]::SetValue("HKEY_...", "ValueName", value)` (preferred for raw HKEY paths) or `Set-ItemProperty -Path HKCU:\... -Name ... -Type DWord -Value ...`. Both appear and either is acceptable; mirror the surrounding block. Note: writes to `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders` use `[microsoft.win32.registry]::SetValue` even though the canonical type for that key is `REG_EXPAND_SZ` — Shell expands env vars either way, and the existing Screenshots/ScreenRecordings entries depend on this behavior.
-5. **Bare `Show-Section` blocks with no `Show-Success`/`Show-Error`** are allowed when the section is just a series of independent registry tweaks (see the long block in `02.Setup01.ps1` lines ~75–135). Don't add logging noise to that style — match what's already there.
-6. **Comments mix English and Traditional Chinese.** Keep new comments in whichever language fits the surrounding block; both are first-class.
+```powershell
+$errors = $null; $tokens = $null
+[System.Management.Automation.Language.Parser]::ParseFile('path\to\script.ps1', [ref]$tokens, [ref]$errors) | Out-Null
+if ($errors) { $errors | ForEach-Object { Write-Host $_ -ForegroundColor Red } }
+```
 
-## Editing / PR / release workflow
+## Branch / commit / PR workflow
 
-- **Branches:** `feat/<slug>`, `fix/<slug>`, `release/<x.y.z>`, `docs/<slug>`. The Copilot coding agent uses `copilot/<slug>`.
-- **Commit messages:** Conventional Commits style (`feat:`, `fix:`, `docs:`, `chore:`). Append this trailer to every commit you author:
+- **Branches:** `feat/<slug>`, `fix/<slug>`, `docs/<slug>`, `release/<x.y.z>`. The Copilot coding agent uses `copilot/<slug>`.
+- **Commits:** Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`). Append this trailer to every commit you author:
   ```
   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
   ```
-- **PRs:** Open against `master`. Squash-merge (`gh pr merge <n> --squash --delete-branch`) is the established pattern.
-- **Validation before opening a PR:** Parse-check any modified PowerShell file — this is the closest thing to a test suite this repo has:
-  ```powershell
-  $errors = $null; $tokens = $null
-  [System.Management.Automation.Language.Parser]::ParseFile('path\to\script.ps1', [ref]$tokens, [ref]$errors) | Out-Null
-  if ($errors) { $errors | ForEach-Object { Write-Host $_ -ForegroundColor Red } }
-  ```
-  Do **not** execute the scripts — they make persistent, system-wide changes.
-- **CHANGELOG.md** follows [Keep a Changelog](https://keepachangelog.com/) with sections `### Added` / `### Fixed` / `### Changed`. New work goes into `## [Unreleased]`.
-- **Releases:** Tags are **lightweight, no `v` prefix** (`1.0.0`, `1.1.1`, `1.2.0`). The flow established by PRs #42 and #48 is:
-  1. On a `release/<x.y.z>` branch, promote `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD` in `CHANGELOG.md` and update the compare-link footer at the bottom of the file (also without `v` prefix).
-  2. Open + merge a `docs: update CHANGELOG for release <x.y.z>` PR.
-  3. On the resulting master commit: `gh release create <x.y.z> --target master --title "<x.y.z>" --notes-file <notes>.md --latest`. This creates the lightweight tag for you; do not pre-create an annotated tag.
+- **PRs:** open against `master`; squash-merge (`gh pr merge <n> --squash --delete-branch`).
+- **User-facing changes** (a new `Step N` script, a tool added/removed, a changed `iex` URL) must update **both** READMEs in the same PR — see the README instructions.
+- **Releases** use lightweight tags with **no `v` prefix** (`1.2.0`) — full flow in the CHANGELOG instructions.
 
-## When to update the READMEs
+## MCP servers & skills
 
-User-facing changes — a new numbered `Step N` script, a new tool that should appear in **What's Included / 包含工具**, a changed `iex` URL — require touching **both** `README.md` and `README.zh-TW.md` in the same PR. The two files are structurally parallel; keep section ordering and code-block contents identical, only the prose changes language.
+Two MCP configs exist for different Copilot surfaces — keep both in mind when adding/removing servers:
+- `.mcp.json` (repo root, Copilot CLI / coding agent): `microsoftdocs/mcp` (Microsoft Learn), `microsoft/markitdown`, `ChromeDevTools/chrome-devtools-mcp`.
+- `.vscode/mcp.json` (VS Code Copilot): `github`, `microsoft-learn`, `io.github.upstash/context7`. Context7 needs a `CONTEXT7_API_KEY` (prompted by VS Code — **do not commit one**).
 
-## Tooling / MCP
+Reusable Copilot **skills** live in `.github/skills/`: `git-commit` (Conventional Commits), `code-review`, `gh-cli`, `github-issues`, `microsoft-docs`, `create-readme`, `chrome-devtools`. Prefer them for those tasks.
 
-- `.vscode/mcp.json` registers three MCP servers for in-editor Copilot: `github`, `microsoft-learn`, and `io.github.upstash/context7`. The Context7 server needs a `CONTEXT7_API_KEY` (prompted by VS Code; do **not** commit one).
-- `.whitesource` exists for Mend (WhiteSource) Renovate; no other CI / linting hooks are wired up.
+`.whitesource` configures Mend / Renovate; there are no other CI or linting hooks.

--- a/.github/instructions/changelog-and-releases.instructions.md
+++ b/.github/instructions/changelog-and-releases.instructions.md
@@ -1,0 +1,18 @@
+---
+description: Changelog format and the release / tag process.
+applyTo: "**/CHANGELOG.md"
+---
+
+# Changelog & release conventions
+
+- Follows **[Keep a Changelog](https://keepachangelog.com/)**. New work goes under `## [Unreleased]`, grouped into `### Added` / `### Fixed` / `### Changed` (a `### Documentation` group is also used). Reference the PR number in each entry, e.g. `... (#46)`.
+- **Tags are lightweight and carry no `v` prefix** — `1.0.0`, `1.1.1`, `1.2.0`. The compare-link footer at the bottom of `CHANGELOG.md` also uses bare versions.
+
+## Release flow (established by #42 and #48)
+
+1. On a `release/<x.y.z>` branch, promote `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD` and update the compare-link footer (add the new `[x.y.z]` link and repoint `[Unreleased]` to `x.y.z...HEAD`).
+2. Open and squash-merge a `docs: update CHANGELOG for release <x.y.z>` PR into `master`.
+3. On the resulting `master` commit, create the GitHub release — this creates the lightweight tag for you, so **do not** pre-create an annotated tag:
+   ```
+   gh release create <x.y.z> --target master --title "<x.y.z>" --notes-file <notes>.md --latest
+   ```

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -1,0 +1,66 @@
+---
+description: Conventions for the standalone PowerShell setup scripts.
+applyTo: "**/*.ps1"
+---
+
+# PowerShell script conventions
+
+Read `.github/copilot-instructions.md` first for the big picture (the `iex` run model, the `master`-branch rule, the `WebClient` ban, and how to parse-check). This file is about writing/editing the scripts themselves.
+
+## Two families, two styles — match the file you're in
+
+1. **The numbered workstation family** — `Environment\ENVIRONMENT-MONEY-INSTALL\00`–`05` and `01.WinUpdate.ps1` — uses the modern `Show-*` + emoji style below. New scripts in this family must follow it.
+2. **Everything else** — `Work\*`, `Scripts\*`, `Shells\*`, `Environment\ENVIRONMENT-MONEY-SANDBOX.ps1` — predates that style and uses plain `Write-Host` / `Write-Warning`, `Break` instead of `exit`, and sometimes `Set-ExecutionPolicy Unrestricted`. Don't impose `Show-*` there; mirror the surrounding file.
+
+## Numbered-family boilerplate (top of every 00–05 script)
+
+1. **Re-declare the `Show-*` helpers verbatim** — `Show-Section`, `Show-Info`, `Show-Warning`, `Show-Error`, `Show-Success`. They are deliberately duplicated per file because each script ships standalone via `iex`; **do not** refactor them into a shared module. (`00/02/03/05` use the multi-line form, `04` uses one-line bodies — both are fine.)
+2. **Gates, in this order:**
+   ```powershell
+   Set-ExecutionPolicy RemoteSigned -Force
+   # WindowsPrincipal IsInRole "Administrator"  -> Show-Error + exit if false
+   if ($PSversionTable.PsVersion.Major -lt 7) { Show-Error ...; exit }   # 01–04 only (see exceptions below)
+   ```
+
+   The PS7 gate has two deliberate exceptions in the 00–05 family: `00.PreConfig.ps1` omits it because it bootstraps PowerShell 7 itself, and `05.Driver.ps1` omits it on purpose — it sets `Tls12` for older sessions and is written to tolerate Windows PowerShell 5.1. Don't add a PS7 gate to either. (The `Show-*` helpers and the admin check are still present in all of 00–05.)
+3. **Emoji-framed phases:** announce each phase with `Show-Section -Message "..." -Emoji "..." -Color "..."`, then `Show-Success` / `Show-Error` after the action. Multi-step phases are numbered inline, e.g. `Show-Section -Message "[3/8] Install Visual Studio Extensions" ...`.
+4. **Bare `Show-Section` blocks with no `Show-Success`/`Show-Error`** are intentional where a section is just a run of independent registry tweaks (e.g. `02.Setup01.ps1` ~lines 75–135). Don't add logging noise there — match what's present.
+
+## `iex` / `$PSScriptRoot` — sibling-file fallback
+
+Under `iex`, `$PSScriptRoot` is empty, so a script that needs a **sibling script or text file** must fall back to the `master` raw URL. The established pattern (from `03.Setup02.ps1`):
+
+```powershell
+$vsixInstallScript = "$PSScriptRoot\install-vsix.ps1"
+if (-not (Test-Path $vsixInstallScript)) {                         # remote-exec fallback
+    $url = "https://raw.githubusercontent.com/lettucebo/Ci.Environment/master/Environment/ENVIRONMENT-MONEY-INSTALL/install-vsix.ps1"
+    Invoke-WebRequest -Uri $url -OutFile $vsixInstallScript
+}
+```
+
+`04.EdgeExtensions.ps1` does the same for `EdgeExtensions.md` via `if ([string]::IsNullOrEmpty($PSScriptRoot)) { ... Invoke-RestMethod ... }`. Any **new** sibling dependency must add the same fallback, and its URL must point at `master/`.
+
+Note: not every `$PSScriptRoot` use has a fallback — the binary-asset steps in `02.Setup01.ps1` (fonts under `Fonts\`, `vs_enterprise.exe`, etc.) reference `$PSScriptRoot\...` directly and only work when the repo is on disk. That is existing behavior; don't "fix" it by inventing download URLs for binaries.
+
+## Registry writes
+
+Two interchangeable styles appear; mirror the surrounding block:
+- `[microsoft.win32.registry]::SetValue("HKEY_CURRENT_USER\...", "ValueName", $value)` — preferred for raw `HKEY_...` paths.
+- `Set-ItemProperty -Path HKCU:\... -Name ... -Type DWord -Value ...`.
+
+Writes to `HKEY_CURRENT_USER\...\Explorer\User Shell Folders` use `[microsoft.win32.registry]::SetValue` even though that key is canonically `REG_EXPAND_SZ` — Shell expands env vars either way, and the existing Screenshots / ScreenRecordings redirects depend on this. Keep that form.
+
+## Other conventions
+
+- **Networking:** fetch this repo's own scripts/text with `Invoke-RestMethod` / `Invoke-WebRequest`, not `(New-Object System.Net.WebClient).DownloadString` — it corrupts their UTF-8 emoji + Traditional Chinese (#45 rewrote the READMEs' `iex` one-liners for this reason). The idiomatic Chocolatey bootstrap `iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))` downloads plain ASCII and is the intentional exception — it is still used in `02.Setup01.ps1`, `05.Driver.ps1`, and `Work\*`.
+- **Comments mix English and Traditional Chinese** — both are first-class; write new comments in whichever language fits the surrounding block.
+
+## Validating (never execute)
+
+Parse-check only — running a script makes persistent, system-wide changes:
+
+```powershell
+$errors = $null; $tokens = $null
+[System.Management.Automation.Language.Parser]::ParseFile('path\to\script.ps1', [ref]$tokens, [ref]$errors) | Out-Null
+if ($errors) { $errors | ForEach-Object { Write-Host $_ -ForegroundColor Red } }
+```

--- a/.github/instructions/readme-and-docs.instructions.md
+++ b/.github/instructions/readme-and-docs.instructions.md
@@ -1,0 +1,11 @@
+---
+description: Keeping the bilingual READMEs and the software list in sync.
+applyTo: "**/README*.md,**/ENVIRONMENT-MONEY.md"
+---
+
+# README & docs conventions
+
+- `README.md` (English) and `README.zh-TW.md` (Traditional Chinese) are **structurally parallel** and must be **updated together in the same PR**. Keep section ordering, headings, and every code block (the `iex` commands) identical — only the prose language differs.
+- Any user-facing change must land in both files: a new numbered **`Step N`** section for a new `NN.*.ps1` script, a tool added/removed under **What's Included / 包含工具**, or a changed `iex` URL.
+- `iex` command blocks always reference the `master` raw URL — see `.github/copilot-instructions.md` for why `master` is the production branch.
+- `ENVIRONMENT-MONEY.md` is the long-form, manual-install software list (Traditional Chinese), linked from the READMEs as the detailed software reference. Update it when the curated tool list changes meaningfully, but it is not required to mirror every script edit.


### PR DESCRIPTION
Split the single `.github/copilot-instructions.md` into a lean always-on overview plus three path-scoped `.github/instructions/*.instructions.md` files (PowerShell scripts, READMEs/docs, changelog/releases), applied via `applyTo` frontmatter.

Also corrects factual issues found during review:
- `install-vsix.ps1` is invoked by `03.Setup02.ps1`, not `02.Setup01.ps1`
- scope the WebClient rule to the repo's own UTF-8 scripts/text (the Chocolatey bootstrap idiom is the intentional exception; #45 only changed the READMEs)
- PS7 gate applies to `01`–`04` only; `05.Driver.ps1` tolerates PowerShell 5.1
- clarify there is no long-lived release branch
- document the root `.mcp.json` and `.github/skills/` that were missing